### PR TITLE
Refactor deep equal

### DIFF
--- a/lib/sinon/util/core/deep-equal.js
+++ b/lib/sinon/util/core/deep-equal.js
@@ -1,54 +1,14 @@
 "use strict";
 
-var div = typeof document !== "undefined" && document.createElement("div");
+var samsam = require("@sinonjs/samsam");
 
 function isReallyNaN(val) {
     return val !== val;
 }
 
-function isDOMNode(obj) {
-    var success = false;
-
-    try {
-        obj.appendChild(div);
-        success = div.parentNode === obj;
-    } catch (e) {
-        return false;
-    } finally {
-        try {
-            obj.removeChild(div);
-        } catch (e) {
-            // Remove failed, not much we can do about that
-        }
-    }
-
-    return success;
-}
-
-function isElement(obj) {
-    return div && obj && obj.nodeType === 1 && isDOMNode(obj);
-}
-
 var deepEqual = module.exports = function deepEqual(a, b) {
     if (typeof a !== "object" || typeof b !== "object") {
         return isReallyNaN(a) && isReallyNaN(b) || a === b;
-    }
-
-    if (isElement(a) || isElement(b)) {
-        return a === b;
-    }
-
-    if (a === b) {
-        return true;
-    }
-
-    if ((a === null && b !== null) || (a !== null && b === null)) {
-        return false;
-    }
-
-    if (a instanceof RegExp && b instanceof RegExp) {
-        return (a.source === b.source) && (a.global === b.global) &&
-            (a.ignoreCase === b.ignoreCase) && (a.multiline === b.multiline);
     }
 
     if (a instanceof Error && b instanceof Error) {
@@ -60,17 +20,14 @@ var deepEqual = module.exports = function deepEqual(a, b) {
         return false;
     }
 
-    if (aString === "[object Date]") {
-        return a.valueOf() === b.valueOf();
+    var matcher = arguments[2];
+    if (!matcher) {
+        return samsam.deepEqual(a, b);
     }
 
     var prop;
     var aLength = 0;
     var bLength = 0;
-
-    if (aString === "[object Array]" && a.length !== b.length) {
-        return false;
-    }
 
     for (prop in a) {
         if (Object.prototype.hasOwnProperty.call(a, prop)) {
@@ -81,7 +38,7 @@ var deepEqual = module.exports = function deepEqual(a, b) {
             }
 
             // allow alternative function for recursion
-            if (!(arguments[2] || deepEqual)(a[prop], b[prop])) {
+            if (!(matcher || deepEqual)(a[prop], b[prop])) {
                 return false;
             }
         }

--- a/lib/sinon/util/core/deep-equal.js
+++ b/lib/sinon/util/core/deep-equal.js
@@ -15,42 +15,25 @@ var deepEqual = module.exports = function deepEqual(a, b) {
         return a === b;
     }
 
-    var aString = Object.prototype.toString.call(a);
-    if (aString !== Object.prototype.toString.call(b)) {
+    if (Object.prototype.toString.call(a) !== Object.prototype.toString.call(b)) {
+        return false;
+    }
+
+    var haveDifferentKeys = Object.keys(a).sort().join() !== Object.keys(b).sort().join();
+    if (haveDifferentKeys) {
         return false;
     }
 
     var matcher = arguments[2];
-    if (!matcher) {
-        return samsam.deepEqual(a, b);
+    if (matcher) {
+        var allKeysMatch = Object.keys(a).every(function (key) {
+            return matcher(a[key], b[key]);
+        });
+
+        return allKeysMatch;
     }
 
-    var prop;
-    var aLength = 0;
-    var bLength = 0;
-
-    for (prop in a) {
-        if (Object.prototype.hasOwnProperty.call(a, prop)) {
-            aLength += 1;
-
-            if (!(prop in b)) {
-                return false;
-            }
-
-            // allow alternative function for recursion
-            if (!(matcher || deepEqual)(a[prop], b[prop])) {
-                return false;
-            }
-        }
-    }
-
-    for (prop in b) {
-        if (Object.prototype.hasOwnProperty.call(b, prop)) {
-            bLength += 1;
-        }
-    }
-
-    return aLength === bLength;
+    return samsam.deepEqual(a, b);
 };
 
 deepEqual.use = function (match) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,11 @@
         }
       }
     },
+    "@sinonjs/samsam": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
+      "integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg=="
+    },
     "@std/esm": {
       "version": "0.25.2",
       "resolved": "https://registry.npmjs.org/@std/esm/-/esm-0.25.2.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@sinonjs/formatio": "^2.0.0",
+    "@sinonjs/samsam": "^2.0.0",
     "diff": "^3.1.0",
     "lodash.get": "^4.4.2",
     "lolex": "^2.2.0",
@@ -69,8 +70,7 @@
     "proxyquire": "^1.8.0",
     "proxyquire-universal": "^1.0.8",
     "proxyquireify": "^3.2.1",
-    "rimraf": "^2.5.3",
-    "samsam": "^1.1.3"
+    "rimraf": "^2.5.3"
   },
   "files": [
     "lib",

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var referee = require("@sinonjs/referee");
-var samsam = require("samsam");
+var samsam = require("@sinonjs/samsam");
 var assert = referee.assert;
 var refute = referee.refute;
 var fakeXhr = require("nise").fakeXhr;

--- a/test/util/core/deep-equal-test.js
+++ b/test/util/core/deep-equal-test.js
@@ -352,4 +352,35 @@ describe("util/core/deepEqual", function () {
         assert(matchDeepEqual(matchA, duplicateA));
         assert.isFalse(matchDeepEqual(matchA, matchB));
     });
+
+    it("handles shallow cyclic objects", function () {
+        var a = {
+            foo: "bar"
+        };
+        a.cyclicKeyName = a;
+
+        var b = {
+            foo: "bar"
+        };
+        b.cyclicKeyName = b;
+
+        assert(deepEqual(a, b));
+    });
+
+    it("handles deep cyclic objects", function () {
+        var a = {
+            foo: "bar",
+            key: { }
+        };
+        a.key.value = a;
+
+        var b = {
+            foo: "bar",
+            key: { }
+        };
+        b.key.value = b;
+
+        assert(deepEqual(a, b));
+    });
+
 });

--- a/test/util/core/deep-equal-test.js
+++ b/test/util/core/deep-equal-test.js
@@ -383,4 +383,20 @@ describe("util/core/deepEqual", function () {
         assert(deepEqual(a, b));
     });
 
+    it("handles cyclic objects when a matcher provided", function () {
+        var matchDeepEqual = deepEqual.use(match);
+
+        var a = {
+            foo: "bar"
+        };
+        a.cyclicKeyName = a;
+
+        var b = {
+            foo: "bar"
+        };
+        b.cyclicKeyName = b;
+
+        assert(matchDeepEqual(a, b));
+    });
+
 });


### PR DESCRIPTION
I looked through deepEqual, which is a bit convoluted because it doesn't use ES5 native methods.

I've done some digging. `deepEqual` was removed from the public API in https://github.com/sinonjs/sinon/commit/e37e1a6c203f1e85005831a2bc874aa0b800e3ad, so we can refactor it freely.

I've done some refactoring to it, which makes it a lot easier to read, in my not so humble opinion.

The problem still persists though, but it makes `deepEqual` easier to understand.