### PR TITLE
Refactor deepEqual

### DIFF
--- a/lib/sinon/util/core/deep-equal.js
+++ b/lib/sinon/util/core/deep-equal.js
@@ -15,42 +15,25 @@ var deepEqual = module.exports = function deepEqual(a, b) {
         return a === b;
     }
 
-    var aString = Object.prototype.toString.call(a);
-    if (aString !== Object.prototype.toString.call(b)) {
+    if (Object.prototype.toString.call(a) !== Object.prototype.toString.call(b)) {
+        return false;
+    }
+
+    var haveDifferentKeys = Object.keys(a).sort().join() !== Object.keys(b).sort().join();
+    if (haveDifferentKeys) {
         return false;
     }
 
     var matcher = arguments[2];
-    if (!matcher) {
-        return samsam.deepEqual(a, b);
+    if (matcher) {
+        var allKeysMatch = Object.keys(a).every(function (key) {
+            return matcher(a[key], b[key]);
+        });
+
+        return allKeysMatch;
     }
 
-    var prop;
-    var aLength = 0;
-    var bLength = 0;
-
-    for (prop in a) {
-        if (Object.prototype.hasOwnProperty.call(a, prop)) {
-            aLength += 1;
-
-            if (!(prop in b)) {
-                return false;
-            }
-
-            // allow alternative function for recursion
-            if (!(matcher || deepEqual)(a[prop], b[prop])) {
-                return false;
-            }
-        }
-    }
-
-    for (prop in b) {
-        if (Object.prototype.hasOwnProperty.call(b, prop)) {
-            bLength += 1;
-        }
-    }
-
-    return aLength === bLength;
+    return samsam.deepEqual(a, b);
 };
 
 deepEqual.use = function (match) {


### PR DESCRIPTION
I looked through deepEqual, which is a bit convoluted because it doesn't use ES5 native methods.

I've done some digging. `deepEqual` was removed from the public API in https://github.com/sinonjs/sinon/commit/e37e1a6c203f1e85005831a2bc874aa0b800e3ad, so we can refactor it freely.

I've done some refactoring to it, which makes it a lot easier to read, in my not so humble opinion.

The problem still persists though, but it makes `deepEqual` easier to understand.